### PR TITLE
adds termstyle module for xplatform color support

### DIFF
--- a/src/nicypkg/functions.nim
+++ b/src/nicypkg/functions.nim
@@ -57,11 +57,12 @@ let
       "zsh"    # default
 
 proc zeroWidth*(s: string): string =
-  if shellName == "bash":
-    return fmt"\[{s}\]"
-  else:
-    # zsh, default
-    return fmt"%{{{s}%}}"
+  return s
+  #if shellName == "bash":
+  #  return fmt"\[{s}\]"
+  #else:
+  #  # zsh, default
+  #  return fmt"%{{{s}%}}"
 
 proc foreground*(s: string, color: Color): string =
   let c = "\x1b[" & $(ord(color)+30) & "m"


### PR DESCRIPTION
Hi! colors don't work on WSL2/windows by default, so I swapped out the color fns with the `termstyle` module.
I know this adds a dependency, but hopefully it's a good case for it.